### PR TITLE
Use tcsetattr & friends and O_NONBLOCK

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ make install
 memSIM -h
 ```
 
-Should build on Linux out of the box.
-Other UN*X may needs some modifications. The are some Linux-specific hacks to make the serial port run at 460800bps.
+Should build on Linux and most POSIX systems out of the box.
 
 Installation
 ------------

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <asm/termios.h>
-#include <asm/ioctls.h>
+#include <termios.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
@@ -56,39 +55,40 @@ const struct MemType memory_types[] =
 };
 
 
-extern int ioctl(int d, unsigned long request, ...);
-
 static int
 serial_open(const char *device)
 {
-   struct termios2 settings;
+   struct termios settings;
    int fd;
-   fd = open(device, O_RDWR);
+   int flags;
+   fd = open(device, O_RDWR | O_NDELAY);
    if (fd < 0)
    {
       perror(device);
       return -1;
    }
-   if (ioctl(fd, TCGETS2, &settings) < 0)
+   
+   if (tcgetattr(fd, &settings) < 0)
    {
-      perror("ioctl TCGETS2 failed");
+      perror("tcgetattr failed");
       close(fd);
       return -1;
    }
-   settings.c_iflag &= ~(IGNBRK | BRKINT | IGNPAR | INPCK | ISTRIP
-         | INLCR | IGNCR | ICRNL | IXON | PARMRK);
-   settings.c_iflag |= IGNBRK | IGNPAR;
-   settings.c_oflag &= ~OPOST;
-   settings.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-   settings.c_cflag &= ~(CSIZE | PARODD | CBAUD | PARENB);
-   settings.c_cflag |= CS8 | BOTHER | CREAD;
-   settings.c_ispeed = BPS;
-   settings.c_ospeed = BPS;
-   if (ioctl(fd, TCSETS2, &settings) < 0)
+   cfmakeraw(&settings);
+   cfsetspeed(&settings, BPS);
+   settings.c_cflag |= CLOCAL;
+   if (tcsetattr(fd, TCSANOW, &settings) < 0)
    {
-      perror("ioctl TCSETS2 failed");
+      perror("tcsetattr failed");
       close(fd);
       return -1;
+   }
+   flags = fcntl(fd, F_GETFL);
+   flags &= ~O_NONBLOCK;
+   if (fcntl(fd, F_SETFL, flags)) {
+     perror("fcntl failed");
+     close(fd);
+     return -1;
    }
    return fd;
 }


### PR DESCRIPTION
This commit changes the serial initialization routine so that the POSIX
tcsetattr functions and friends are used instead of Linux specific termios2
ioctls.  Also, the device is opened with O_NONBLOCK during initialization
so that the CLOCAL can be set.  This prevents the initialization code from
hanging if the default modes require CD to be present on the serial port
(i.e. ~CLOCAL mode).